### PR TITLE
Add new keybinds to close Woomer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Zoomer application for wayland (linux) inspired by [tsoding's boomer](https://gi
 
 ## Controls
 
-| Control                                           | Description                                                   |
-|---------------------------------------------------|---------------------------------------------------------------|
-| Right Click or <kbd>ESC</kbd>                     | Quit the application.                                         |
-| <kbd>R</kbd>                                      | Reload the shaders (only for Developer mode)                  |
-| Hold <kbd>CTRL</kbd>                              | Enable flashlight effect.                                     |
-| Drag with left mouse button                       | Move the image around.                                        |
-| Scroll wheel                                      | Zoom in/out.                                                  |
-| <kbd>Ctrl</kbd> + <kbd>SHIFT</kbd> + Scroll wheel | Change the radius of the flashlight.                          |
+| Control                                                   | Description                                  |
+|-----------------------------------------------------------|----------------------------------------------|
+| Right Click, <kbd>ESC</kbd>, <kbd>A</kbd> or <kbd>Q</kbd> | Quit the application.                        |
+| <kbd>R</kbd>                                              | Reload the shaders (only for Developer mode) |
+| Hold <kbd>CTRL</kbd>                                      | Enable flashlight effect.                    |
+| Drag with left mouse button                               | Move the image around.                       |
+| Scroll wheel                                              | Zoom in/out.                                 |
+| <kbd>Ctrl</kbd> + <kbd>SHIFT</kbd> + Scroll wheel         | Change the radius of the flashlight.         |
 
 ## HiDPI Displays
 ### Hyprland

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,12 @@ fn main() {
     cursor_position_uniform_location = spotlight_shader.get_shader_location("cursorPosition");
     spotlight_radius_multiplier_uniform_location =
         spotlight_shader.get_shader_location("spotlightRadiusMultiplier");
-    while !rl.window_should_close() {
+    let mut should_exit = false;
+    while !rl.window_should_close() && !should_exit {
+        // We check for A and Q due to differences between AZERTY and QWERTY keyboard layouts
+        if rl.is_key_pressed(KeyboardKey::KEY_Q) || rl.is_key_pressed(KeyboardKey::KEY_A) {
+            should_exit = true;
+        }
         if rl.is_mouse_button_down(MouseButton::MOUSE_BUTTON_RIGHT) {
             break;
         }


### PR DESCRIPTION
This PR simply adds two new keybinds in order to close Woomer. That is a personal improvement I want to merge since I recently moved to Wayland and Woomer, and I am still used to use `Q` to close the app since I was using Boomer on Xorg.

The added keybinds are `Q` and `A` since I did not wanted to struggle to detect the keyboard layout of the user.
I've also updated the README file with the two new keybinds.

Thank you for taking the time of reviewing my pull request!
